### PR TITLE
Include set-array source directly in gen-mapping project

### DIFF
--- a/packages/gen-mapping/package.json
+++ b/packages/gen-mapping/package.json
@@ -49,7 +49,6 @@
   "author": "Justin Ridgewell <justin@ridgewell.name>",
   "license": "MIT",
   "dependencies": {
-    "@jridgewell/set-array": "^1.2.1",
     "@jridgewell/sourcemap-codec": "1.4.16-beta.0",
     "@jridgewell/trace-mapping": "^0.3.24"
   }

--- a/packages/gen-mapping/src/gen-mapping.ts
+++ b/packages/gen-mapping/src/gen-mapping.ts
@@ -1,4 +1,4 @@
-import { SetArray, put, remove } from '@jridgewell/set-array';
+import { SetArray, put, remove } from './set-array';
 import { encode, encodeGeneratedRanges, encodeOriginalScopes } from '@jridgewell/sourcemap-codec';
 import { TraceMap, decodedMappings } from '@jridgewell/trace-mapping';
 

--- a/packages/gen-mapping/src/set-array.ts
+++ b/packages/gen-mapping/src/set-array.ts
@@ -1,0 +1,82 @@
+type Key = string | number | symbol;
+
+/**
+ * SetArray acts like a `Set` (allowing only one occurrence of a string `key`), but provides the
+ * index of the `key` in the backing array.
+ *
+ * This is designed to allow synchronizing a second array with the contents of the backing array,
+ * like how in a sourcemap `sourcesContent[i]` is the source content associated with `source[i]`,
+ * and there are never duplicates.
+ */
+export class SetArray<T extends Key = Key> {
+  private declare _indexes: Record<T, number | undefined>;
+  declare array: readonly T[];
+
+  constructor() {
+    this._indexes = { __proto__: null } as any;
+    this.array = [];
+  }
+}
+
+interface PublicSet<T extends Key> {
+  array: T[];
+  _indexes: SetArray<T>['_indexes'];
+}
+
+/**
+ * Typescript doesn't allow friend access to private fields, so this just casts the set into a type
+ * with public access modifiers.
+ */
+function cast<T extends Key>(set: SetArray<T>): PublicSet<T> {
+  return set as any;
+}
+
+/**
+ * Gets the index associated with `key` in the backing array, if it is already present.
+ */
+export function get<T extends Key>(setarr: SetArray<T>, key: T): number | undefined {
+  return cast(setarr)._indexes[key];
+}
+
+/**
+ * Puts `key` into the backing array, if it is not already present. Returns
+ * the index of the `key` in the backing array.
+ */
+export function put<T extends Key>(setarr: SetArray<T>, key: T): number {
+  // The key may or may not be present. If it is present, it's a number.
+  const index = get(setarr, key);
+  if (index !== undefined) return index;
+
+  const { array, _indexes: indexes } = cast(setarr);
+
+  const length = array.push(key);
+  return (indexes[key] = length - 1);
+}
+
+/**
+ * Pops the last added item out of the SetArray.
+ */
+export function pop<T extends Key>(setarr: SetArray<T>): void {
+  const { array, _indexes: indexes } = cast(setarr);
+  if (array.length === 0) return;
+
+  const last = array.pop()!;
+  indexes[last] = undefined;
+}
+
+/**
+ * Removes the key, if it exists in the set.
+ */
+export function remove<T extends Key>(setarr: SetArray<T>, key: T): void {
+  const index = get(setarr, key);
+  if (index === undefined) return;
+
+  const { array, _indexes: indexes } = cast(setarr);
+  for (let i = index + 1; i < array.length; i++) {
+    const k = array[i];
+    array[i - 1] = k;
+    indexes[k]!--;
+  }
+  indexes[key] = undefined;
+  array.pop();
+}

--- a/packages/gen-mapping/test/set-array.test.ts
+++ b/packages/gen-mapping/test/set-array.test.ts
@@ -1,0 +1,169 @@
+import { SetArray, get, put, pop, remove } from '../src/set-array';
+import { strict as assert } from 'assert';
+
+describe('SetArray', () => {
+  describe('get()', () => {
+    it('returns undefined if not present', () => {
+      const array = new SetArray();
+
+      assert.equal(get(array, 'test'), undefined);
+      assert.equal(get(array, 'foo'), undefined);
+
+      put(array, 'test');
+      assert.equal(get(array, 'test'), 0);
+
+      assert.equal(get(array, 'foo'), undefined);
+      put(array, 'foo');
+      assert.equal(get(array, 'foo'), 1);
+
+      assert.deepEqual(array.array, ['test', 'foo']);
+    });
+  });
+
+  describe('put()', () => {
+    it('puts string in if not present', () => {
+      const array = new SetArray();
+
+      put(array, 'test');
+      assert.deepEqual(array.array, ['test']);
+      put(array, 'test');
+      assert.deepEqual(array.array, ['test']);
+
+      put(array, 'foo');
+      assert.deepEqual(array.array, ['test', 'foo']);
+      put(array, 'bar');
+      assert.deepEqual(array.array, ['test', 'foo', 'bar']);
+
+      put(array, 'bar');
+      assert.deepEqual(array.array, ['test', 'foo', 'bar']);
+      put(array, 'foo');
+      assert.deepEqual(array.array, ['test', 'foo', 'bar']);
+    });
+
+    it('returns index of string in array', () => {
+      const array = new SetArray();
+
+      assert.equal(put(array, 'test'), 0);
+      assert.equal(put(array, 'foo'), 1);
+      assert.equal(put(array, 'bar'), 2);
+    });
+
+    it('returns original index of string in array', () => {
+      const array = new SetArray();
+
+      put(array, 'test');
+      put(array, 'foo');
+      put(array, 'bar');
+
+      assert.equal(put(array, 'test'), 0);
+      assert.equal(put(array, 'foo'), 1);
+      assert.equal(put(array, 'bar'), 2);
+    });
+
+    it('handles empty string', () => {
+      const array = new SetArray();
+
+      assert.equal(put(array, ''), 0);
+      assert.equal(put(array, ''), 0);
+      assert.deepEqual(array.array, ['']);
+    });
+  });
+
+  describe('pop()', () => {
+    it('removes last item from array', () => {
+      const array = new SetArray();
+
+      put(array, 'test');
+      put(array, 'foo');
+      put(array, 'bar');
+
+      pop(array);
+      assert.deepEqual(array.array, ['test', 'foo']);
+      pop(array);
+      assert.deepEqual(array.array, ['test']);
+      pop(array);
+      assert.deepEqual(array.array, []);
+    });
+
+    it('unsets the key', () => {
+      const array = new SetArray();
+
+      put(array, 'test');
+      pop(array);
+      assert.equal(get(array, 'test'), undefined);
+    });
+
+    it('putting afterwards writes to array at old index', () => {
+      const array = new SetArray();
+
+      put(array, 'test');
+      pop(array);
+      put(array, 'foo');
+      assert.deepEqual(array.array, ['foo']);
+    });
+
+    it('getting after put gets old key ', () => {
+      const array = new SetArray();
+
+      put(array, 'test');
+      pop(array);
+      put(array, 'foo');
+      assert.equal(get(array, 'foo'), 0);
+    });
+  });
+
+  describe('remove()', () => {
+    it('removes item from array', () => {
+      const array = new SetArray();
+
+      put(array, 'test');
+      put(array, 'foo');
+      put(array, 'bar');
+
+      remove(array, 'foo');
+      assert.deepEqual(array.array, ['test', 'bar']);
+      remove(array, 'bar');
+      assert.deepEqual(array.array, ['test']);
+      remove(array, 'test');
+      assert.deepEqual(array.array, []);
+    });
+
+    it('unsets the key', () => {
+      const array = new SetArray();
+
+      put(array, 'test');
+      remove(array, 'test');
+      assert.equal(get(array, 'test'), undefined);
+    });
+
+    it('updates indexes of following keys', () => {
+      const array = new SetArray();
+
+      put(array, 'test');
+      put(array, 'foo');
+      put(array, 'bar');
+
+      remove(array, 'foo');
+      assert.equal(get(array, 'test'), 0);
+      assert.equal(get(array, 'bar'), 1);
+    });
+
+    it('putting afterwards writes to array at old index', () => {
+      const array = new SetArray();
+
+      put(array, 'test');
+      remove(array, 'test');
+      put(array, 'foo');
+      assert.deepEqual(array.array, ['foo']);
+    });
+
+    it('getting after put gets old key ', () => {
+      const array = new SetArray();
+
+      put(array, 'test');
+      remove(array, 'test');
+      put(array, 'foo');
+      assert.equal(get(array, 'foo'), 0);
+    });
+  });
+});


### PR DESCRIPTION
closes https://github.com/jridgewell/set-array/issues/2

I was a little surprised there's no lockfile in the repo, so I wasn't quite sure what package manager you use - I've had good luck using `pnpm` with monorepos. But this seemed to build and pass the tests locally