### PR TITLE
fix: use stable version of sourcemap-codec dependency

### DIFF
--- a/packages/gen-mapping/package.json
+++ b/packages/gen-mapping/package.json
@@ -50,7 +50,7 @@
   "author": "Justin Ridgewell <justin@ridgewell.name>",
   "license": "MIT",
   "dependencies": {
-    "@jridgewell/sourcemap-codec": "1.4.16-beta.0",
+    "@jridgewell/sourcemap-codec": "^1.5.0",
     "@jridgewell/trace-mapping": "^0.3.24"
   }
 }


### PR DESCRIPTION
1.4.16-beta.0 doesn't dedup against 1.5.0, so both end up in the dependency tree. This should fix that