### PR TITLE
Range mappings: update encoding to latest

### DIFF
--- a/packages/gen-mapping/test/gen-mapping.test.ts
+++ b/packages/gen-mapping/test/gen-mapping.test.ts
@@ -156,7 +156,7 @@ describe('GenMapping', () => {
       addSegment(map, 0, 1, 'input.js', 2, 3, 'foo');
       setRangeSegment(map, 0, 1);
 
-      assert.deepEqual(toEncodedMap(map).rangeMappings, 'B');
+      assert.deepEqual(toEncodedMap(map).rangeMappings, 'A');
     });
 
     it('excludes rangeMappings when empty', () => {

--- a/packages/sourcemap-codec/src/range-mappings.ts
+++ b/packages/sourcemap-codec/src/range-mappings.ts
@@ -12,7 +12,7 @@ export function decodeRangeMappings(input: string): RangeMappings {
   do {
     const semi = reader.indexOf(';');
     const indices: MappingIndex[] = [];
-    let index = -1;
+    let index = 0;
 
     while (reader.pos < semi) {
       index += decodeInteger(reader);
@@ -35,7 +35,7 @@ export function encodeRangeMappings(decoded: RangeMappings): string {
     const indices = decoded[i];
     if (i > 0) writer.write(semicolon);
 
-    let index = -1;
+    let index = 0;
     for (let j = 0; j < indices.length; j++) {
       const offset = indices[j];
       encodeInteger(writer, offset - index);

--- a/packages/sourcemap-codec/test/range-mappings.test.ts
+++ b/packages/sourcemap-codec/test/range-mappings.test.ts
@@ -13,19 +13,19 @@ describe('range mappings proposal', () => {
         decoded: [[]],
       },
       {
-        encoded: 'B',
+        encoded: 'A',
         decoded: [[0]],
       },
       {
-        encoded: ';BC;',
+        encoded: ';AC;',
         decoded: [[], [0, 2], []],
       },
       {
-        encoded: 'C;BC;E',
+        encoded: 'B;AC;D',
         decoded: [[1], [0, 2], [3]],
       },
       {
-        encoded: 'nF;BPP;9I',
+        encoded: 'mF;APP;8I',
         decoded: [[166], [0, 15, 30], [284]],
       },
     ];

--- a/packages/trace-mapping/test/flatten-map.test.ts
+++ b/packages/trace-mapping/test/flatten-map.test.ts
@@ -59,7 +59,7 @@ describe('FlattenMap', () => {
                 sourcesContent: ['thirdsource'],
                 sourceRoot: 'nested',
                 mappings: 'AAAAA,CAAA;AAAA',
-                rangeMappings: 'B',
+                rangeMappings: 'A',
               },
             },
             {
@@ -144,7 +144,7 @@ describe('FlattenMap', () => {
     it('rangeMappings', () => {
       const tracer = new FlattenMap(map);
       assert.deepEqual(decodedRangeMappings(tracer), [[], [], [0, 1]]);
-      assert.deepEqual(encodedRangeMappings(tracer), ';;BB');
+      assert.deepEqual(encodedRangeMappings(tracer), ';;AB');
     });
   });
 

--- a/packages/trace-mapping/test/trace-mapping.test.ts
+++ b/packages/trace-mapping/test/trace-mapping.test.ts
@@ -919,7 +919,7 @@ describe('TraceMap', () => {
           sources: ['input.js'],
           names: [],
           mappings: 'AAAA;EAee', // (0,0) -> (0,0) RANGE; (1,2) -> (15,15) NORMAL
-          rangeMappings: 'B', // first segment is range
+          rangeMappings: 'A', // first segment is range
         });
 
         // Inside range


### PR DESCRIPTION
This PR updates the range mappings decoding/encoding to match the latest spec changes in: https://github.com/tc39/ecma426/pull/252

Tests for sourcemap-codec, trace-mapping, gen-mapping should pass. I think there are existing test failures in source-maps and remapping that I think are unchanged with this PR.